### PR TITLE
Add DNS enumeration from LDAP

### DIFF
--- a/pkg/ldapsession/search.go
+++ b/pkg/ldapsession/search.go
@@ -3,6 +3,7 @@ package ldapsession
 import (
 	"errors"
 	"fmt"
+
 	"github.com/go-ldap/ldap/v3"
 	"github.com/sirupsen/logrus"
 )
@@ -43,7 +44,24 @@ func (w *LDAPSession) ManualWriteSearchResultsToChan(results *ldap.SearchResult)
 	for _, control := range results.Controls {
 		w.Channels.Controls <- control
 	}
+}
 
+func (w *LDAPSession) ManualWriteMultipleSearchResultsToChan(multipleResults []*ldap.SearchResult) {
+	defer w.CloseChannels()
+
+	for _, results := range multipleResults {
+		w.Log.Debugf("received search results, writing %d entries to channel", len(results.Entries))
+
+		for _, entry := range results.Entries {
+			w.Channels.Entries <- entry
+		}
+		for _, referral := range results.Referrals {
+			w.Channels.Referrals <- referral
+		}
+		for _, control := range results.Controls {
+			w.Channels.Controls <- control
+		}
+	}
 }
 
 // ExecuteSearchRequest performs a paged search and writes results to the LDAPsession's defined results channel.

--- a/pkg/ldapsession/search.go
+++ b/pkg/ldapsession/search.go
@@ -175,12 +175,12 @@ PagedSearch:
 // keeping the results channels open until the end of the last one
 func (w *LDAPSession) ExecuteBulkSearchRequest(searchRequests []*ldap.SearchRequest) error {
 	w.keepChannelsOpen()
+	defer w.CloseChannels()
 	for _, request := range searchRequests {
 		err := w.ExecuteSearchRequest(request)
 		if err != nil {
 			return err
 		}
 	}
-	w.CloseChannels()
 	return nil
 }

--- a/pkg/ldapsession/session.go
+++ b/pkg/ldapsession/session.go
@@ -43,6 +43,7 @@ type ResultChannels struct {
 	Entries   chan *ldap.Entry
 	Referrals chan string
 	Controls  chan ldap.Control
+	keepOpen bool
 }
 
 type DomainInfo struct {
@@ -152,8 +153,16 @@ func (w *LDAPSession) NewChannels(ctx context.Context) {
 		Entries:   make(chan *ldap.Entry),
 		Referrals: make(chan string),
 		Controls:  make(chan ldap.Control),
+		keepOpen: false,
 	}
 	w.ctx = ctx
+}
+
+// If you call this, the results channels will not automatically close when a search is finished and
+// will need to be manually closed with CloseChannels(). Be careful here - this can
+// cause all sorts of concurrency race conditions
+func (w *LDAPSession) keepChannelsOpen() {
+	w.Channels.keepOpen = true
 }
 
 func (w *LDAPSession) CloseChannels() {

--- a/pkg/modules/README.md
+++ b/pkg/modules/README.md
@@ -83,11 +83,66 @@ The module lets you specify a custom LDAP syntax filter to run, and returns all 
 
 **Example Usage**: 
 ```
-$ ./bin/windapsearch -d lab.ropnop.com -u agreen@lab.ropnop.com -p GoPadres98 -m custom --filter "(sAMAccountName=thoffman)" --attrs pwdLastSet -j | jq .
+$ ./bin/windapsearch -d lab.ropnop.com -u agreen@lab.ropnop.com -p $PASS -m custom --filter "(sAMAccountName=thoffman)" --attrs pwdLastSet -j | jq .
 [
   {
     "dn": "CN=Trevor Hoffman,OU=users,OU=LAB,DC=lab,DC=ropnop,DC=com",
     "pwdLastSet": "2019-05-16T18:39:48.1597266-05:00"
+  }
+]
+```
+
+## dns-names
+**Description**: `Query AD integrated DNS for domain names`
+
+**Default Attrs**: `name, dnsTombstoned`
+
+**Base Filter**: `(objectClass=*)`
+
+**Additional Options**: ``
+
+The module queries the Active Directory integrated DNS and returns all objects. Unfortunately, there is no attribute for the complete FQDN, therefore the dn is returned, containing sufficient information to recover the actual FQDN.
+
+**Example Usage**: 
+```
+$ ./bin/windapsearch -d lab.ropnop.com -u agreen@lab.ropnop.com -p $PASS -m dns-names -j | jq .
+[
+  {
+    "dn": "DC=sharepoint,DC=lab.ropnop.com,CN=MicrosoftDNS,DC=DomainDnsZones,DC=lab,DC=ropnop,DC=com"
+  },
+  {
+    "dn": "DC=dc,DC=lab.ropnop.com,CN=MicrosoftDNS,DC=DomainDnsZones,DC=lab,DC=ropnop,DC=com"
+  },
+  {
+    "dn": "DC=app01,DC=lab.ropnop.com,CN=MicrosoftDNS,DC=DomainDnsZones,DC=lab,DC=ropnop,DC=com"
+  },
+  ...
+]
+
+```
+
+## dns-zones
+**Description**: `Query AD integrated DNS for registered zones`
+
+**Default Attrs**: `dn, name`
+
+**Base Filter**: `(&(objectClass=dnsZone)(!name=RootDNSServers)(!name=*.in-addr.arpa)(!name=_msdcs.*)(!name=..TrustAnchors))`
+
+**Additional Options**: ``
+
+The module queries the Active Directory integrated DNS and returns all DNS zones. Unfortunately, there is no attribute for the complete FQDN, therefore the dn is returned, containing sufficient information to recover the actual FQDN.
+
+**Example Usage**: 
+```
+$ ./bin/windapsearch -d lab.ropnop.com -u agreen@lab.ropnop.com -p $PASS -m dns-zones -j | jq .
+[
+  {
+    "dn": "DC=lab.ropnop.com,CN=MicrosoftDNS,DC=DomainDnsZones,DC=lab,DC=ropnop,DC=com",
+    "name": "lab.ropnop.com"
+  },
+  {
+    "dn": "DC=dev.ropnop.net,CN=MicrosoftDNS,DC=DomainDnsZones,DC=dev,DC=ropnop,DC=net",
+    "name": "dev.ropnop.net"
   }
 ]
 ```

--- a/pkg/modules/README.md
+++ b/pkg/modules/README.md
@@ -8,6 +8,8 @@ The following modules have been implemented, with functionality copied from the 
  * [admin-objects](#admin-objects)
  * [computers](#computers)
  * [custom](#custom)
+ * [dns-names](#dns-names)
+ * [dns-zones](#dns-zones)  
  * [domain-admins](#domain-admins)
  * [gpos](#gpos)
  * [groups](#groups)

--- a/pkg/modules/dnsnames.go
+++ b/pkg/modules/dnsnames.go
@@ -2,11 +2,11 @@ package modules
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/go-ldap/ldap/v3"
+	"github.com/ropnop/go-windapsearch/pkg/adschema"
 	"github.com/ropnop/go-windapsearch/pkg/ldapsession"
 	"github.com/spf13/pflag"
+	"strings"
 )
 
 type DnsNamesModule struct{}
@@ -29,52 +29,44 @@ func (d DnsNamesModule) FlagSet() *pflag.FlagSet {
 }
 
 func (d DnsNamesModule) DefaultAttrs() []string {
-	return []string{"dn"}
+	return []string{"name", "dnsTombstoned"}
+}
+
+// Optional function for the module interface that will be called by searchResultWorker
+// This will hide by default a lot of extraneous entries we usually don't care about
+// use '--ignore-display-filters' to bypass this and display everything
+func (d DnsNamesModule) DisplayFilter(entry *adschema.ADEntry) bool {
+	locations := []string{"CN=MicrosoftDNS,DC=DomainDnsZones,%s", "CN=MicrosoftDNS,DC=ForestDnsZones,%s", "CN=MicrosoftDNS,CN=System,%s"}
+	dnContainsFilter := []string{"DC=RootDNSServers", "in-addr.arpa,", "DC=_msdcs", "..TrustAnchors"}
+	dnBeginsFilter := []string{"DC=DomainDnsZones,", "DC=ForestDnsZones,", "DC=_kerberos.", "DC=_ldap.", "DC=_kpasswd.", "DC=_gc.", "DC=@", "DC=_autodiscover."}
+	for _, filterEntry := range dnContainsFilter { // Filter entries like rDNS zones
+		if strings.Contains(entry.DN, filterEntry) {
+			return false
+		}
+	}
+	for _, filterEntry := range dnBeginsFilter { // filter entries used for discovery, e.g. _ldap
+		if strings.HasPrefix(entry.DN, filterEntry) {
+			return false
+		}
+	}
+	for _, filterEntry := range locations { // filter the zone entries themselves
+		if strings.HasPrefix(entry.DN, fmt.Sprintf(filterEntry, "")) {
+			return false
+		}
+	}
+	return true
+
 }
 
 func (d DnsNamesModule) Run(session *ldapsession.LDAPSession, attrs []string) error {
 	locations := []string{"CN=MicrosoftDNS,DC=DomainDnsZones,%s", "CN=MicrosoftDNS,DC=ForestDnsZones,%s", "CN=MicrosoftDNS,CN=System,%s"}
-
-	// I'm too stupid for filtering these entries via LDAP, tried for about a day and failed... now they're implemented here, feel free to improve this
-	dnContainsFilter := []string{"DC=RootDNSServers", "in-addr.arpa,", "DC=_msdcs", "..TrustAnchors"}
-	dnBeginsFilter := []string{"DC=DomainDnsZones,", "DC=ForestDnsZones,", "DC=_kerberos.", "DC=_ldap.", "DC=_kpasswd.", "DC=_gc.", "DC=@", "DC=_autodiscover."}
-	baseDN := session.BaseDN
-	results := make([]*ldap.SearchResult, 0)
+	var searchRequests []*ldap.SearchRequest
 	for _, location := range locations {
-		session.BaseDN = fmt.Sprintf(location, baseDN)
+		dn := fmt.Sprintf(location, session.BaseDN)
 
-		searchReq := session.MakeSimpleSearchRequest("(objectClass=*)", attrs)
-		res, err := session.GetSearchResults(searchReq)
-
-		if err != nil {
-			return err
-		}
-		filteredResults := make([]*ldap.Entry, 0)
-	outer:
-		for _, entry := range res.Entries {
-			for _, filterEntry := range dnContainsFilter { // Filter entries like rDNS zones
-				if strings.Contains(entry.DN, filterEntry) {
-					continue outer
-				}
-			}
-			for _, filterEntry := range dnBeginsFilter { // filter entries used for discovery, e.g. _ldap
-				if strings.HasPrefix(entry.DN, filterEntry) {
-					continue outer
-				}
-			}
-			for _, filterEntry := range locations { // filter the zone entries themselves
-				if strings.HasPrefix(entry.DN, fmt.Sprintf(filterEntry, "")) {
-					continue outer
-				}
-			}
-			filteredResults = append(filteredResults, entry)
-		}
-		res.Entries = filteredResults
-
-		results = append(results, res)
+		searchReq := session.MakeSearchRequestWithDN(dn, "(objectClass=*)", attrs)
+		searchRequests = append(searchRequests, searchReq)
 	}
-	session.BaseDN = baseDN
 
-	session.ManualWriteMultipleSearchResultsToChan(results)
-	return nil
+	return session.ExecuteBulkSearchRequest(searchRequests)
 }

--- a/pkg/modules/dnsnames.go
+++ b/pkg/modules/dnsnames.go
@@ -1,0 +1,80 @@
+package modules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/ropnop/go-windapsearch/pkg/ldapsession"
+	"github.com/spf13/pflag"
+)
+
+type DnsNamesModule struct{}
+
+func init() {
+	AllModules = append(AllModules, new(DnsNamesModule))
+}
+
+func (d DnsNamesModule) Name() string {
+	return "dns-names"
+}
+
+func (d DnsNamesModule) Description() string {
+	return "List all DNS Names"
+}
+
+func (d DnsNamesModule) FlagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet(d.Name(), pflag.ExitOnError)
+	return flags
+}
+
+func (d DnsNamesModule) DefaultAttrs() []string {
+	return []string{"dn"}
+}
+
+func (d DnsNamesModule) Run(session *ldapsession.LDAPSession, attrs []string) error {
+	locations := []string{"CN=MicrosoftDNS,DC=DomainDnsZones,%s", "CN=MicrosoftDNS,DC=ForestDnsZones,%s", "CN=MicrosoftDNS,CN=System,%s"}
+
+	// I'm too stupid for filtering these entries via LDAP, tried for about a day and failed... now they're implemented here, feel free to improve this
+	dnContainsFilter := []string{"DC=RootDNSServers", "in-addr.arpa,", "DC=_msdcs", "..TrustAnchors"}
+	dnBeginsFilter := []string{"DC=DomainDnsZones,", "DC=ForestDnsZones,", "DC=_kerberos.", "DC=_ldap.", "DC=_kpasswd.", "DC=_gc.", "DC=@", "DC=_autodiscover."}
+	baseDN := session.BaseDN
+	results := make([]*ldap.SearchResult, 0)
+	for _, location := range locations {
+		session.BaseDN = fmt.Sprintf(location, baseDN)
+
+		searchReq := session.MakeSimpleSearchRequest("(objectClass=*)", attrs)
+		res, err := session.GetSearchResults(searchReq)
+
+		if err != nil {
+			return err
+		}
+		filteredResults := make([]*ldap.Entry, 0)
+	outer:
+		for _, entry := range res.Entries {
+			for _, filterEntry := range dnContainsFilter { // Filter entries like rDNS zones
+				if strings.Contains(entry.DN, filterEntry) {
+					continue outer
+				}
+			}
+			for _, filterEntry := range dnBeginsFilter { // filter entries used for discovery, e.g. _ldap
+				if strings.HasPrefix(entry.DN, filterEntry) {
+					continue outer
+				}
+			}
+			for _, filterEntry := range locations { // filter the zone entries themselves
+				if strings.HasPrefix(entry.DN, fmt.Sprintf(filterEntry, "")) {
+					continue outer
+				}
+			}
+			filteredResults = append(filteredResults, entry)
+		}
+		res.Entries = filteredResults
+
+		results = append(results, res)
+	}
+	session.BaseDN = baseDN
+
+	session.ManualWriteMultipleSearchResultsToChan(results)
+	return nil
+}

--- a/pkg/modules/dnszones.go
+++ b/pkg/modules/dnszones.go
@@ -1,0 +1,54 @@
+package modules
+
+import (
+	"fmt"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/ropnop/go-windapsearch/pkg/ldapsession"
+	"github.com/spf13/pflag"
+)
+
+type DnsZonesModule struct{}
+
+func init() {
+	AllModules = append(AllModules, new(DnsZonesModule))
+}
+
+func (d DnsZonesModule) Name() string {
+	return "dns-zones"
+}
+
+func (d DnsZonesModule) Description() string {
+	return "List all DNS Zones"
+}
+
+func (d DnsZonesModule) FlagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet(d.Name(), pflag.ExitOnError)
+	return flags
+}
+
+func (d DnsZonesModule) DefaultAttrs() []string {
+	return []string{"name"}
+}
+
+func (d DnsZonesModule) Run(session *ldapsession.LDAPSession, attrs []string) error {
+	locations := []string{"CN=MicrosoftDNS,DC=DomainDnsZones,%s", "CN=MicrosoftDNS,DC=ForestDnsZones,%s", "CN=MicrosoftDNS,CN=System,%s"}
+	baseDN := session.BaseDN
+	results := make([]*ldap.SearchResult, 0)
+	for _, location := range locations {
+		session.BaseDN = fmt.Sprintf(location, baseDN)
+
+		searchReq := session.MakeSimpleSearchRequest("(&(objectClass=dnsZone)(!name=RootDNSServers)(!name=*.in-addr.arpa)(!name=_msdcs.*)(!name=..TrustAnchors))", attrs)
+		res, err := session.GetSearchResults(searchReq)
+
+		if err != nil {
+			return err
+		}
+
+		results = append(results, res)
+	}
+	session.BaseDN = baseDN
+
+	session.ManualWriteMultipleSearchResultsToChan(results)
+	return nil
+}

--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"github.com/ropnop/go-windapsearch/pkg/adschema"
 	"github.com/ropnop/go-windapsearch/pkg/ldapsession"
 	"github.com/spf13/pflag"
 )
@@ -11,6 +12,23 @@ type Module interface {
 	FlagSet() *pflag.FlagSet
 	DefaultAttrs() []string
 	Run(session *ldapsession.LDAPSession, attrs []string) error
+}
+
+
+type ModuleWithDisplayFilter interface {
+	//DisplayFilter is an optional function for a module used to filter what results get written to the output
+	//it's best to try and filter the request, but when that's not possible, a custom function can be provided
+	//that takes an LDAP entry and returns true/false (whether to display or not)
+	DisplayFilter(e *adschema.ADEntry) bool
+}
+
+// Hacky way to have "DisplayFilter" be optional for the Module interface - if it exists, call it, if not, just return true
+func DisplayFilter(m Module, e *adschema.ADEntry) bool {
+	if moduleWithDisplayFilter, ok := m.(ModuleWithDisplayFilter); ok {
+		return moduleWithDisplayFilter.DisplayFilter(e)
+	} else {
+		return true
+	}
 }
 
 var AllModules []Module

--- a/pkg/windapsearch/results.go
+++ b/pkg/windapsearch/results.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/ropnop/go-windapsearch/pkg/adschema"
 	"github.com/ropnop/go-windapsearch/pkg/ldapsession"
+	"github.com/ropnop/go-windapsearch/pkg/modules"
 	"io"
 	"sync"
 )
@@ -49,6 +50,10 @@ func (w *WindapSearchSession) searchResultWorker(chans *ldapsession.ResultChanne
 			}
 			w.Log.WithField("DN", entry.DN).Debug("parsing entry")
 			e := &adschema.ADEntry{entry}
+			if !w.Options.IgnoreDisplayFilters && !modules.DisplayFilter(w.Module, e) {
+				w.Log.WithField("DN", e.DN).Debug("skipping entry due to module display filter")
+				continue
+			}
 			if !w.Options.JSON {
 				out <- []byte(e.LDAPFormat())
 			} else {

--- a/pkg/windapsearch/windapsearch.go
+++ b/pkg/windapsearch/windapsearch.go
@@ -35,25 +35,26 @@ type CommandLineOptions struct {
 	Help             bool
 	Domain           string
 	DomainController string
-	Username         string
-	Password         string
-	NTLMHash         string
-	UseNTLM          bool
-	Port             int
-	Proxy            string
-	Secure           bool
-	ResolveHosts     bool
-	Attributes       []string
-	FullAttributes   bool
-	Output           string
-	JSON             bool
-	Module           string
-	Interactive      bool
-	Version          bool
-	Verbose          bool
-	Debug            bool
-	PageSize         int
-	ModuleFlags      *pflag.FlagSet
+	Username             string
+	Password             string
+	NTLMHash             string
+	UseNTLM              bool
+	Port                 int
+	Proxy                string
+	Secure               bool
+	ResolveHosts         bool
+	Attributes           []string
+	FullAttributes       bool
+	IgnoreDisplayFilters bool
+	Output               string
+	JSON                 bool
+	Module               string
+	Interactive          bool
+	Version              bool
+	Verbose              bool
+	Debug                bool
+	PageSize             int
+	ModuleFlags          *pflag.FlagSet
 }
 
 func NewSession() *WindapSearchSession {
@@ -71,6 +72,7 @@ func NewSession() *WindapSearchSession {
 	wFlags.BoolVar(&w.Options.Secure, "secure", false, "Use LDAPS. This will not verify TLS certs, however. (default: false)")
 	wFlags.StringVar(&w.Options.Proxy, "proxy", "", "SOCKS5 Proxy to use (e.g. 127.0.0.1:9050)")
 	wFlags.BoolVar(&w.Options.FullAttributes, "full", false, "Output all attributes from LDAP")
+	wFlags.BoolVar(&w.Options.IgnoreDisplayFilters, "ignore-display-filters", false, "Ignore any display filters set by the module and always output every entry")
 	wFlags.StringVarP(&w.Options.Output, "output", "o", "", "Save results to file")
 	wFlags.BoolVarP(&w.Options.JSON, "json", "j", false, "Convert LDAP output to JSON")
 	wFlags.IntVar(&w.Options.PageSize, "page-size", 1000, "LDAP page size to use")


### PR DESCRIPTION
This PR adds enumeration of DNS zones, see https://dirkjanm.io/getting-in-the-zone-dumping-active-directory-dns-with-adidnsdump/

Unfortunately, this topic is a bit difficult...:
- The LDAP attributes of some of the entries are protected, to find all of them the base DN has to be specified quite concisely. As there are three possible locations, querying all of them required a more liberal `ManualWriteSearchResultsToChan` that allows more than one `*ldap.SearchResult` as argument 
- There are some zones like root DNS server zones that are of no particular interest and filtered out by default. While this works quite well for the dns-zones query, I banged my head against filtering the other entries (like names used for service discovery, e.g. `__kerberos`) by DNs containing a substring, without success. Therefore, the filtering is done manually.
- Most dnsNode entries are protected, meaning that it is not possible to read details like their names. Therefore, I only retrieve their DN as this is enough information to resolve them afterwards
- There is no resolution of the entries. I felt this isn't something go-windapsearch should take care of, but it should be quite easy to add if the feature is desired

Unfortunately, this pull request also contains my other pull request #9 because I needed it for developing/testing and apparently messed up my local checkout, I'm really sorry for that. I can try to fix this, but my git experience is that in 90% of cases, things just get worse. If this is a blocker for merging, I will try cleaning this up.